### PR TITLE
Systemd

### DIFF
--- a/control
+++ b/control
@@ -44,6 +44,13 @@ Architecture: any
 Description: Applications for the Jaiabot Project
  Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
 
+Package: jaiabot-python
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Section: science
+Architecture: all
+Description: Python applications and virtual environment (venv) for the Jaiabot Project
+ Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+
 Package: jaiabot-doc
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: doc

--- a/control
+++ b/control
@@ -51,6 +51,15 @@ Architecture: all
 Description: Python applications and virtual environment (venv) for the Jaiabot Project
  Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
 
+
+Package: jaiabot-config
+Depends: ${shlibs:Depends}, ${misc:Depends}
+Section: science
+Architecture: all
+Description: Configuration generation for the Jaiabot Project
+ Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+
+
 Package: jaiabot-doc
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: doc

--- a/control
+++ b/control
@@ -27,7 +27,7 @@ Depends: libjaiabot (= ${binary:Version}),
          libgoby3-moos-dev,
          libgoby3-gui-dev
 Description: Developers' package for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: libjaiabot
 Section: libs
@@ -35,41 +35,46 @@ Architecture: any
 Multi-Arch: same
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Libraries for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-apps
 Depends: libjaiabot (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Section: science
 Architecture: any
 Description: Applications for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-python
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3
 Section: science
 Architecture: all
 Description: Python applications and virtual environment (venv) for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
-
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-config
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: science
 Architecture: all
 Description: Configuration generation for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
-
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-doc
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: doc
 Architecture: all
 Description: Documentation for the Jaiabot Project
- Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-interfaces
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: doc
 Architecture: all
 Description: Interfaces definition files for the Jaiabot Project
-  Jaiabot provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle.
+  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
+
+Package: jaiabot-embedded
+Depends: jaiabot-apps, jaiabot-python, jaiabot-config, debconf
+Section: science
+Architecture: all
+Description: Metapackage the install the required code for the embedded bot/hub computer and configures it.
+ The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/

--- a/control
+++ b/control
@@ -73,7 +73,8 @@ Description: Interfaces definition files for the Jaiabot Project
   The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-embedded
-Depends: jaiabot-apps, jaiabot-python, jaiabot-config, debconf
+Depends: debconf, goby3-apps, goby3-moos, jaiabot-apps, moos-ivp-apps, moosdb10, jaiabot-python, jaiabot-config
+Recommends: goby3-gui
 Section: science
 Architecture: all
 Description: Metapackage the install the required code for the embedded bot/hub computer and configures it.

--- a/control
+++ b/control
@@ -48,14 +48,14 @@ Package: jaiabot-python
 Depends: ${shlibs:Depends}, ${misc:Depends}, python3
 Section: science
 Architecture: all
-Description: Python applications and virtual environment (venv) for the Jaiabot Project
+Description: Python applications and virtual environment (venv) of the Python dependencies for the Jaiabot Project
  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-config
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Section: science
 Architecture: all
-Description: Configuration generation for the Jaiabot Project
+Description: Runtime configuration generation for the Jaiabot Project applications
  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-doc
@@ -73,9 +73,13 @@ Description: Interfaces definition files for the Jaiabot Project
   The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-embedded
-Depends: debconf, goby3-apps, goby3-moos, jaiabot-apps, moos-ivp-apps, moosdb10, jaiabot-python, jaiabot-config
+Depends: debconf,
+         goby3-apps, goby3-moos,
+         jaiabot-apps, jaiabot-python, jaiabot-config,
+         moos-ivp-apps, moosdb10, libmoos-ivp,
+         gpsd
 Recommends: goby3-gui
 Section: science
 Architecture: all
-Description: Metapackage the install the required code for the embedded bot/hub computer and configures it.
+Description: Metapackage tp install the required code for the embedded bot or hub computer and configure it using debconf.
  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/

--- a/jaiabot-config.install
+++ b/jaiabot-config.install
@@ -1,0 +1,1 @@
+usr/share/jaiabot/config/*

--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -1,0 +1,21 @@
+#!/bin/sh -e
+
+# Source debconf library.
+. /usr/share/debconf/confmodule
+
+db_input high jaiabot-embedded/type || true
+db_go
+
+db_get jaiabot-embedded/type
+JAIA_TYPE=$RET
+if [ "$JAIA_TYPE" = "bot" ]; then
+    db_input high jaiabot-embedded/bot_id || true
+    db_go
+elif [ "$JAIA_TYPE" = "hub" ]; then
+    db_input high jaiabot-embedded/hub_id || true
+    db_go
+fi
+
+db_input high jaiabot-embedded/fleet_id || true
+db_go
+

--- a/jaiabot-embedded.install
+++ b/jaiabot-embedded.install
@@ -1,1 +1,2 @@
-# This package doesn't install anything itself, just a meta-package to install the right jaiabot packages and then configure them
+/etc/update-motd.d/*
+

--- a/jaiabot-embedded.install
+++ b/jaiabot-embedded.install
@@ -1,0 +1,1 @@
+# This package doesn't install anything itself, just a meta-package to install the right jaiabot packages and then configure them

--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -1,0 +1,46 @@
+#!/bin/bash
+set -e
+
+. /usr/share/debconf/confmodule
+
+db_get jaiabot-embedded/type
+JAIA_TYPE=$RET
+
+if [ "$JAIA_TYPE" = "bot" ]; then
+    db_get jaiabot-embedded/bot_id
+    BOT_OR_HUB_INDEX=$RET
+elif [ "$JAIA_TYPE" = "hub" ]; then
+    db_get jaiabot-embedded/hub_id
+    BOT_OR_HUB_INDEX=$RET    
+fi
+
+db_get jaiabot-embedded/fleet_id
+FLEET_INDEX=$RET
+
+
+OLD_HOST_NAME=`/bin/hostname`
+NEW_HOST_NAME=jaia${JAIA_TYPE}${BOT_OR_HUB_INDEX}
+
+if [[ "$NEW_HOST_NAME" != "$OLD_HOST_NAME" ]]; then
+    echo "Setting hostname to $NEW_HOST_NAME (log out and in again for the prompt to change)"
+     /usr/bin/hostnamectl set-hostname $NEW_HOST_NAME
+     sed -i "s/^\(127\.0\.[0-9\.]*\).*${OLD_HOST_NAME}$/\1\t${NEW_HOST_NAME}/" /etc/hosts
+     /bin/systemctl restart networking
+fi
+
+# Install systemd services and enable them
+/usr/share/jaiabot/config/gen/systemd.py ${JAIA_TYPE} \
+                                         --enable \
+                                         --jaiabot_bin_dir=/usr/bin \
+                                         --jaiabot_share_dir=/usr/share \
+                                         --goby_bin_dir=/usr/bin \
+                                         --moos_bin_dir=/usr/bin \
+                                         --gen_dir=/usr/share/jaiabot/config/gen \
+                                         --systemd_dir=/etc/systemd/system \
+                                         --bot_index=${BOT_OR_HUB_INDEX} \
+                                         --hub_index=${BOT_OR_HUB_INDEX} \
+                                         --fleet_index=${FLEET_INDEX}
+
+#DEBHELPER#
+
+exit 0

--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -25,7 +25,6 @@ if [[ "$NEW_HOST_NAME" != "$OLD_HOST_NAME" ]]; then
     echo "Setting hostname to $NEW_HOST_NAME (log out and in again for the prompt to change)"
      /usr/bin/hostnamectl set-hostname $NEW_HOST_NAME
      sed -i "s/^\(127\.0\.[0-9\.]*\).*${OLD_HOST_NAME}$/\1\t${NEW_HOST_NAME}/" /etc/hosts
-     /bin/systemctl restart networking
 fi
 
 # Install systemd services and enable them
@@ -40,6 +39,10 @@ fi
                                          --bot_index=${BOT_OR_HUB_INDEX} \
                                          --hub_index=${BOT_OR_HUB_INDEX} \
                                          --fleet_index=${FLEET_INDEX}
+
+
+echo "Starting jaiabot software"
+/bin/systemctl start jaiabot
 
 #DEBHELPER#
 

--- a/jaiabot-embedded.postrm
+++ b/jaiabot-embedded.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+if [ "$1" = "purge" -a -e /usr/share/debconf/confmodule ]; then
+    # Source debconf library.
+    . /usr/share/debconf/confmodule
+    # Remove my changes to the db.
+    db_purge
+fi
+
+exit 0

--- a/jaiabot-embedded.prerm
+++ b/jaiabot-embedded.prerm
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+echo "Stopping jaiabot software"
+/bin/systemctl stop jaiabot || true
+
+shopt -s nullglob
+echo "Disabling and removing systemd services"
+for service_file in /etc/systemd/system/jaiabot*.service; do
+    service_name=$(basename $service_file)
+    echo "Disabling $service_name"
+    /bin/systemctl disable $service_name
+    echo "Removing $service_file"
+    rm $service_file
+done
+
+#DEBHELPER#
+
+exit 0

--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -1,0 +1,27 @@
+Template: jaiabot-embedded/type
+Type: select
+Choices: bot, hub
+Description: Is this a bot or a hub?
+  This choice will determine which applications will be configured to launch with systemd.
+
+Template: jaiabot-embedded/bot_id
+Type: select
+Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+Description: Bot identification number
+  This is used to set the hostname of the computer and set the correct value in the jaiabot configuration.
+  To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"
+
+Template: jaiabot-embedded/hub_id
+Type: select
+Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+Description: Hub identification number
+  This is used to set the hostname of the computer and set the correct value in the jaiabot configuration.
+  To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"
+
+
+Template: jaiabot-embedded/fleet_id
+Type: select
+Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50
+Description: Fleet identification number
+  This is used to set the correct value in the jaiabot configuration.
+  To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"

--- a/jaiabot-python.install
+++ b/jaiabot-python.install
@@ -1,1 +1,1 @@
-usr/share/jaiabot-python/*
+usr/share/jaiabot/python/*

--- a/jaiabot-python.install
+++ b/jaiabot-python.install
@@ -1,0 +1,1 @@
+usr/share/jaiabot-python/*

--- a/rules
+++ b/rules
@@ -30,3 +30,7 @@ $(info $$DEB_CMAKE_EXTRA_FLAGS is [${DEB_CMAKE_EXTRA_FLAGS}])
 
 CC=/usr/bin/clang 
 CXX=/usr/bin/clang++
+
+# dh_strip errors on some of the code in the jaiabot-python package (venv)
+DEB_DH_STRIP_ARGS_jaiabot-python += --exclude jaiabot-python
+DEB_DH_SHLIBDEPS_ARGS_jaiabot-python += --exclude jaiabot-python


### PR DESCRIPTION
Debian packaging updates to support this PR: https://github.com/jaiarobotics/jaiabot/pull/29

- Add `jaiabot-python` package for Jaiabot Python scripts and virtual environment (venv) for dependencies).
- Add `jaiabot-config` package for runtime configuration generation scripts and templates.
- Add `jaiabot-embedded` package as a "one stop shop" metapackage for installing on the embedded board for the hub/bot.
  - Include scripts for generating, enabling, and starting systemd services within the package installation/removal.