### PR TITLE
Add n_bots to debconf

### DIFF
--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -22,3 +22,6 @@ fi
 db_input high jaiabot-embedded/fleet_id || true
 db_go
 
+db_input high jaiabot-embedded/n_bots || true
+db_go
+

--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -26,6 +26,8 @@ fi
 db_get jaiabot-embedded/fleet_id
 FLEET_INDEX=$RET
 
+db_get jaiabot-embedded/n_bots
+N_BOTS=$RET
 
 OLD_HOST_NAME=`/bin/hostname`
 NEW_HOST_NAME=jaia${JAIA_TYPE}${BOT_OR_HUB_INDEX}-fleet${FLEET_INDEX}
@@ -49,7 +51,8 @@ echo ">>>>> Installing and enabling systemd services ... "
                                          --systemd_dir=/etc/systemd/system \
                                          --bot_index=${BOT_OR_HUB_INDEX} \
                                          --hub_index=${BOT_OR_HUB_INDEX} \
-                                         --fleet_index=${FLEET_INDEX}
+                                         --fleet_index=${FLEET_INDEX} \
+                                         --n_bots=${N_BOTS}
 
 echo "<<<<< Installing and enabling systemd services complete!"
 

--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -19,6 +19,13 @@ Description: Hub identification number
   To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"
 
 
+Template: jaiabot-embedded/n_bots
+Type: select
+Choices: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32
+Description: Number of bots
+  This is the number of bots in the fleet, used by the intervehicle comms.
+  To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"
+
 Template: jaiabot-embedded/fleet_id
 Type: select
 Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50


### PR DESCRIPTION
Prompt the user for the number of bots in the fleet as part of the debconf setup when first installing (or `dpkg-reconfigure`'ing)  jaiabot-embedded.