### PR TITLE
Do not automatically enable wireguard when installing/updating jaiabot-embedded

### DIFF
--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -74,7 +74,6 @@ echo ">>>>> Installing and enabling Wireguard VPN ... "
 
 /usr/share/jaiabot/config/gen/wireguard.py ${JAIA_TYPE} \
                                          --name wg_jaia \
-                                         --enable \
                                          --bot_index=${BOT_OR_HUB_INDEX} \
                                          --hub_index=${BOT_OR_HUB_INDEX} \
                                          --fleet_index=${FLEET_INDEX}

--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -70,7 +70,7 @@ echo ">>>>> Installing and enabling systemd services ... "
 
 echo "<<<<< Installing and enabling systemd services complete!"
 
-echo ">>>>> Installing and enabling Wireguard VPN ... "
+echo ">>>>> Installing (but not enabling) Wireguard VPN ... "
 
 /usr/share/jaiabot/config/gen/wireguard.py ${JAIA_TYPE} \
                                          --name wg_jaia \
@@ -78,7 +78,7 @@ echo ">>>>> Installing and enabling Wireguard VPN ... "
                                          --hub_index=${BOT_OR_HUB_INDEX} \
                                          --fleet_index=${FLEET_INDEX}
 
-echo ">>>>> Installing and enabling Wireguard VPN complete!"
+echo ">>>>> Installing Wireguard VPN complete!"
 
 
 echo ">>>>> Starting jaiabot services ... "


### PR DESCRIPTION
This is now a manual process so clients can choose to enable WG as desired.