### PR TITLE
Jaiab 309/xbee radio driver updates for multihub

### DIFF
--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -33,9 +33,6 @@ fi
 db_input high jaiabot-embedded/fleet_id || true
 db_go
 
-db_input high jaiabot-embedded/n_bots || true
-db_go
-
 db_input high jaiabot-embedded/led_type || true
 db_go
 

--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -28,9 +28,6 @@ fi
 db_get jaiabot-embedded/fleet_id
 FLEET_INDEX=$RET
 
-db_get jaiabot-embedded/n_bots
-N_BOTS=$RET
-
 OLD_HOST_NAME=`/bin/hostname`
 NEW_HOST_NAME=${JAIA_TYPE}${BOT_OR_HUB_INDEX}-fleet${FLEET_INDEX}
 
@@ -80,7 +77,6 @@ JAIA_LED_TYPE=$RET
                                          --bot_index=${BOT_OR_HUB_INDEX} \
                                          --hub_index=${BOT_OR_HUB_INDEX} \
                                          --fleet_index=${FLEET_INDEX} \
-                                         --n_bots=${N_BOTS} \
                                          ${SYSTEMD_SIM_FLAG} \
 					 --led_type=${JAIA_LED_TYPE}
 

--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -20,14 +20,14 @@ Description: At what multiple of real speed should this simulation be run?
 
 Template: jaiabot-embedded/bot_id
 Type: select
-Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150
 Description: Bot identification number
   This is used to set the hostname of the computer and set the correct value in the jaiabot configuration.
   To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"
 
 Template: jaiabot-embedded/hub_id
 Type: select
-Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31
+Choices: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30
 Description: Hub identification number
   This is used to set the hostname of the computer and set the correct value in the jaiabot configuration.
   To change in the future, run "sudo dpkg-reconfigure jaiabot-embedded"


### PR DESCRIPTION
Requires https://github.com/jaiarobotics/jaiabot/pull/408
- Updates list of configurable bots and hubs to match limits set in 
- Removes n_bots setting as this is no longer necessary