### PR TITLE
Fix build failures from missing nodejs dependency in arm64 build

### DIFF
--- a/control
+++ b/control
@@ -8,12 +8,13 @@ Build-Depends: cdbs (>= 0.4.130~),
                libgoby3-dev,
                libgoby3-moos-dev,
                libgoby3-gui-dev,
-               goby3-interfaces [amd64],
-               goby3-clang-tool [amd64],
                protobuf-compiler,
                libnanopb-dev,
-               nanopb,
-               python3-protobuf [amd64],
+               nanopb
+Build-Depends-Indep:
+               python3-protobuf,
+               goby3-clang-tool,
+               goby3-interfaces,
                nodejs,
                webpack,
                npm


### PR DESCRIPTION
See https://app.circleci.com/pipelines/github/jaiarobotics/jaiabot/4075/workflows/64ae9c1f-4716-4d5b-abad-d3c2fba30603/jobs/8275

As the _arm_ builds don't need nodejs, this PR fixes the issue by segregating the dependencies required for the binary packages (in Build-Depends) from those required for the `all` (arch independent) packages (in Build-Depends-Indep).