### PR TITLE
Task/apt cacher

### DIFF
--- a/control
+++ b/control
@@ -62,6 +62,7 @@ Architecture: all
 Description: Web UI applications for the Jaiabot Project
  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 Replaces: jaiabot-data-vision
+Conflicts: jaiabot-data-vision
 
 Package: jaiabot-arduino
 Depends: ${shlibs:Depends}, ${misc:Depends}, avrdude

--- a/jaiabot-python.postinst
+++ b/jaiabot-python.postinst
@@ -13,8 +13,9 @@ pushd /usr/share/jaiabot/python
 
     # /tmp does not necessarily have enough space on the embedded boards, but /var/log is large
     mkdir -p /var/log/tmp
-    pip3 --cache-dir /var/log/tmp install wheel
-    pip3 --cache-dir /var/log/tmp install -r requirements.txt
+    export TMPDIR=/var/log/tmp
+    pip3 install wheel
+    pip3 install -r requirements.txt
     rm -rf /var/log/tmp
 
     deactivate

--- a/jaiabot-python.postinst
+++ b/jaiabot-python.postinst
@@ -10,8 +10,12 @@ pushd /usr/share/jaiabot/python
     /usr/bin/python3 -m venv venv
 
     source venv/bin/activate
-    pip3 install wheel
-    pip3 install -r requirements.txt
+
+    # /tmp does not necessarily have enough space on the embedded boards, but /var/log is large
+    mkdir -p /var/log/tmp
+    pip3 --cache-dir /var/log/tmp install wheel
+    pip3 --cache-dir /var/log/tmp install -r requirements.txt
+    rm -rf /var/log/tmp
 
     deactivate
 popd


### PR DESCRIPTION
Supports https://github.com/jaiarobotics/jaiabot/pull/783

- Change pip temp directory for low-RAM systems (e.g., default VirtualBox VM) so that the tmpfs (RAM disk) used for /tmp is not filled when running `pip install`
- Add `Conflicts:` on `jaiabot-web` with old `jaiabot-data-vision` package so this package is removed on upgrade, if present.