### PR TITLE
Task/add debconf back button

### DIFF
--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -29,34 +29,34 @@ go_menu() {
 configure_common() {
     local state="type"
     while true; do
-        db_set jaiabot-embedded/common_debconf_state $state
+        db_set jaiabot-embedded/debconf_state_common $state
         case $state in
             "type")
                 if debconf_input_and_go high jaiabot-embedded/type; then
                     state="fleet_id"
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             "fleet_id")
                 if debconf_input_and_go high jaiabot-embedded/fleet_id; then
                     state="led_type"
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             "led_type")
                 if debconf_input_and_go high jaiabot-embedded/led_type; then
                     state="electronics_stack"
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             "electronics_stack")
                 if debconf_input_and_go high jaiabot-embedded/electronics_stack; then
                     state="mode"
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             "mode")
@@ -69,7 +69,7 @@ configure_common() {
                         return 0  # Success, end configuration
                     fi
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             # only ask if mode == simulation
@@ -77,7 +77,7 @@ configure_common() {
                 if debconf_input_and_go medium jaiabot-embedded/warp; then
                     return 0  # Success, end configuration
                 else
-                    go_menu jaiabot-embedded/common_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_common
                 fi
                 ;;
             "NEXT")
@@ -95,7 +95,7 @@ configure_common() {
 configure_bot() {
     local state="bot_id"
     while true; do
-        db_set jaiabot-embedded/bot_debconf_state $state
+        db_set jaiabot-embedded/debconf_state_bot $state
         case $state in
             "BACK")
                 return 1
@@ -104,7 +104,7 @@ configure_bot() {
                 if debconf_input_and_go high jaiabot-embedded/bot_id; then
                     state="arduino_type"
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
                 fi
                 ;;
             "arduino_type")
@@ -117,14 +117,14 @@ configure_bot() {
                     fi
                     state="imu_type"
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
                 fi
                 ;;
             "imu_type")
                 if debconf_input_and_go high jaiabot-embedded/imu_type; then
                     state="bot_type"
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
 
                 fi
                 ;;
@@ -132,7 +132,7 @@ configure_bot() {
                 if debconf_input_and_go high jaiabot-embedded/bot_type; then
                     state="data_offload_ignore_type"
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
 
                 fi
                 ;;
@@ -140,14 +140,14 @@ configure_bot() {
                 if debconf_input_and_go medium jaiabot-embedded/data_offload_ignore_type; then
                     state="imu_install_type"
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
                 fi
                 ;;
             "imu_install_type")
                 if debconf_input_and_go high jaiabot-embedded/imu_install_type; then
                     return 0  # success, end configuration
                 else
-                    go_menu jaiabot-embedded/bot_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_bot
 
                 fi
                 ;;
@@ -166,7 +166,7 @@ configure_bot() {
 configure_hub() {
     local state="hub_id"
     while true; do
-        db_set jaiabot-embedded/hub_debconf_state $state
+        db_set jaiabot-embedded/debconf_state_hub $state
         case $state in
             "BACK")
                 return 1
@@ -175,14 +175,14 @@ configure_hub() {
                 if debconf_input_and_go high jaiabot-embedded/hub_id; then
                     state="user_role"
                 else
-                    go_menu jaiabot-embedded/hub_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_hub
                 fi
                 ;;
             "user_role")
                 if debconf_input_and_go medium jaiabot-embedded/user_role; then
                     return 0  # success, end configuration
                 else
-                    go_menu jaiabot-embedded/hub_debconf_state
+                    go_menu jaiabot-embedded/debconf_state_hub
                 fi
                 ;;            
             "EXIT")

--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -17,67 +17,74 @@ debconf_input_and_go() {
     fi
 }
 
-# State machine for shared configuration
-configure_shared() {
-    local state="TYPE"
+go_menu() {
+    db_fset $1 seen false
+    db_input high $1 || true
+    db_go
+    db_get $1
+    state=$RET
+}
+
+# State machine for common configuration
+configure_common() {
+    local state="type"
     while true; do
+        db_set jaiabot-embedded/common_debconf_state $state
         case $state in
-            "TYPE")
+            "type")
                 if debconf_input_and_go high jaiabot-embedded/type; then
-                    state="FLEET_ID"
+                    state="fleet_id"
+                else
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
-            "FLEET_ID")
+            "fleet_id")
                 if debconf_input_and_go high jaiabot-embedded/fleet_id; then
-                    state="LED_TYPE"
+                    state="led_type"
                 else
-                    state="TYPE"
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
-            "LED_TYPE")
+            "led_type")
                 if debconf_input_and_go high jaiabot-embedded/led_type; then
-                    state="ELECTRONICS_STACK"
+                    state="electronics_stack"
                 else
-                    state="FLEET_ID"
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
-            "ELECTRONICS_STACK")
+            "electronics_stack")
                 if debconf_input_and_go high jaiabot-embedded/electronics_stack; then
-                    state="USER_ROLE"
+                    state="mode"
                 else
-                    state="LED_TYPE"
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
-            "USER_ROLE")
-                if debconf_input_and_go medium jaiabot-embedded/user_role; then
-                    state="MODE"
-                else
-                    state="ELECTRONICS_STACK"
-                fi
-                ;;
-            "MODE")
+            "mode")
                 if debconf_input_and_go medium jaiabot-embedded/mode; then
                     db_get jaiabot-embedded/mode
                     JAIA_MODE=$RET
                     if [ "$JAIA_MODE" = "simulation" ]; then
-                        state="WARP"
+                        state="warp"
                     else
                         return 0  # Success, end configuration
                     fi
                 else
-                    state="USER_ROLE"
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
             # only ask if mode == simulation
-            "WARP")
+            "warp")
                 if debconf_input_and_go medium jaiabot-embedded/warp; then
                     return 0  # Success, end configuration
                 else
-                    state="MODE"
+                    go_menu jaiabot-embedded/common_debconf_state
                 fi
                 ;;
+            "NEXT")
+                return 0
+                ;;
             *)
-                echo "Invalid state encountered in configure_shared: $state"
+                echo "Invalid state encountered in configure_common: $state"
                 return 1
                 ;;
         esac
@@ -86,53 +93,66 @@ configure_shared() {
 
 # State machine for "bot" configuration
 configure_bot() {
-    local state="BOT_ID"
+    local state="bot_id"
     while true; do
+        db_set jaiabot-embedded/bot_debconf_state $state
         case $state in
-            "BOT_ID")
+            "BACK")
+                return 1
+                ;;
+            "bot_id")
                 if debconf_input_and_go high jaiabot-embedded/bot_id; then
-                    state="ARDUINO_TYPE"
+                    state="arduino_type"
+                else
+                    go_menu jaiabot-embedded/bot_debconf_state
                 fi
                 ;;
-            "ARDUINO_TYPE")
+            "arduino_type")
                 if debconf_input_and_go high jaiabot-embedded/arduino_type; then
                     db_get jaiabot-embedded/arduino_type
                     ARDUINO_TYPE=$RET
+                    # backwards compatibility for old arduino_type settings
                     if [ "$ARDUINO_TYPE" = "usb_old" ] || [ "$ARDUINO_TYPE" = "usb_new" ]; then
                         db_set jaiabot-embedded/arduino_type usb
                     fi
-                    state="IMU_TYPE"
+                    state="imu_type"
                 else
-                    state="BOT_ID"
+                    go_menu jaiabot-embedded/bot_debconf_state
                 fi
                 ;;
-            "IMU_TYPE")
+            "imu_type")
                 if debconf_input_and_go high jaiabot-embedded/imu_type; then
-                    state="BOT_TYPE"
+                    state="bot_type"
                 else
-                    state="ARDUINO_TYPE"
+                    go_menu jaiabot-embedded/bot_debconf_state
+
                 fi
                 ;;
-            "BOT_TYPE")
+            "bot_type")
                 if debconf_input_and_go high jaiabot-embedded/bot_type; then
-                    state="DATA_OFFLOAD_IGNORE_TYPE"
+                    state="data_offload_ignore_type"
                 else
-                    state="IMU_TYPE"
+                    go_menu jaiabot-embedded/bot_debconf_state
+
                 fi
                 ;;
-            "DATA_OFFLOAD_IGNORE_TYPE")
-                if debconf_input_and_go high jaiabot-embedded/data_offload_ignore_type; then
-                    state="IMU_INSTALL_TYPE"
+            "data_offload_ignore_type")
+                if debconf_input_and_go medium jaiabot-embedded/data_offload_ignore_type; then
+                    state="imu_install_type"
                 else
-                    state="BOT_TYPE"
+                    go_menu jaiabot-embedded/bot_debconf_state
                 fi
                 ;;
-            "IMU_INSTALL_TYPE")
+            "imu_install_type")
                 if debconf_input_and_go high jaiabot-embedded/imu_install_type; then
-                    return 0  # Success, end configuration
+                    return 0  # success, end configuration
                 else
-                    state="DATA_OFFLOAD_IGNORE_TYPE"
+                    go_menu jaiabot-embedded/bot_debconf_state
+
                 fi
+                ;;
+            "EXIT")
+                return 0
                 ;;
             *)
                 echo "Invalid state encountered in configure_bot: $state"
@@ -144,13 +164,29 @@ configure_bot() {
 
 # State machine for "hub" configuration
 configure_hub() {
-    local state="HUB_ID"
+    local state="hub_id"
     while true; do
+        db_set jaiabot-embedded/hub_debconf_state $state
         case $state in
-            "HUB_ID")
+            "BACK")
+                return 1
+                ;;
+            "hub_id")
                 if debconf_input_and_go high jaiabot-embedded/hub_id; then
-                    return 0  # Success, end configuration
+                    state="user_role"
+                else
+                    go_menu jaiabot-embedded/hub_debconf_state
                 fi
+                ;;
+            "user_role")
+                if debconf_input_and_go medium jaiabot-embedded/user_role; then
+                    return 0  # success, end configuration
+                else
+                    go_menu jaiabot-embedded/hub_debconf_state
+                fi
+                ;;            
+            "EXIT")
+                return 0
                 ;;
             *)
                 echo "Invalid state encountered in configure_hub: $state"
@@ -160,14 +196,42 @@ configure_hub() {
     done
 }
 
-# Invoke the shared configuration state machine (both bot/hub settings)
-configure_shared
+# State machine for overall configuration
+configure() {
+    local state="CONFIGURE_COMMON"
+    while true; do
+        case $state in
+            "CONFIGURE_COMMON")
+                if configure_common; then
+                    db_get jaiabot-embedded/type
+                    JAIA_TYPE=$RET                    
+                    if [ "$JAIA_TYPE" = "bot" ]; then
+                        state="CONFIGURE_BOT"
+                    elif [ "$JAIA_TYPE" = "hub" ]; then
+                        state="CONFIGURE_HUB"
+                    fi
+                fi
+                ;;
+            "CONFIGURE_BOT")
+                if configure_bot; then
+                    return 0  # Success, end configuration
+                else
+                    state="CONFIGURE_COMMON"
+                fi
+                ;;            
+            "CONFIGURE_HUB")
+                if configure_hub; then
+                    return 0  # Success, end configuration
+                else
+                    state="CONFIGURE_COMMON"
+                fi
+                ;;            
+            *)
+                echo "Invalid state encountered in configure: $state"
+                return 1
+                ;;
+        esac
+    done
+}
 
-db_get jaiabot-embedded/type
-JAIA_TYPE=$RET
-
-if [ "$JAIA_TYPE" = "bot" ]; then
-    configure_bot
-elif [ "$JAIA_TYPE" = "hub" ]; then
-    configure_hub
-fi
+configure

--- a/jaiabot-embedded.config
+++ b/jaiabot-embedded.config
@@ -3,60 +3,171 @@
 # Source debconf library.
 . /usr/share/debconf/confmodule
 
-db_input high jaiabot-embedded/type || true
-db_go
+# Enable backup capability
+db_capb backup
 
-db_input medium jaiabot-embedded/mode || true
-db_go
+# General function for handling debconf input and go
+# Returns 0 if the user moves forward, 1 if the user chooses to back up
+debconf_input_and_go() {
+    db_input "$1" "$2" || true
+    if db_go; then
+        return 0
+    else
+        return 1
+    fi
+}
 
-db_get jaiabot-embedded/mode
-JAIA_MODE=$RET
+# State machine for shared configuration
+configure_shared() {
+    local state="TYPE"
+    while true; do
+        case $state in
+            "TYPE")
+                if debconf_input_and_go high jaiabot-embedded/type; then
+                    state="FLEET_ID"
+                fi
+                ;;
+            "FLEET_ID")
+                if debconf_input_and_go high jaiabot-embedded/fleet_id; then
+                    state="LED_TYPE"
+                else
+                    state="TYPE"
+                fi
+                ;;
+            "LED_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/led_type; then
+                    state="ELECTRONICS_STACK"
+                else
+                    state="FLEET_ID"
+                fi
+                ;;
+            "ELECTRONICS_STACK")
+                if debconf_input_and_go high jaiabot-embedded/electronics_stack; then
+                    state="USER_ROLE"
+                else
+                    state="LED_TYPE"
+                fi
+                ;;
+            "USER_ROLE")
+                if debconf_input_and_go medium jaiabot-embedded/user_role; then
+                    state="MODE"
+                else
+                    state="ELECTRONICS_STACK"
+                fi
+                ;;
+            "MODE")
+                if debconf_input_and_go medium jaiabot-embedded/mode; then
+                    db_get jaiabot-embedded/mode
+                    JAIA_MODE=$RET
+                    if [ "$JAIA_MODE" = "simulation" ]; then
+                        state="WARP"
+                    else
+                        return 0  # Success, end configuration
+                    fi
+                else
+                    state="USER_ROLE"
+                fi
+                ;;
+            # only ask if mode == simulation
+            "WARP")
+                if debconf_input_and_go medium jaiabot-embedded/warp; then
+                    return 0  # Success, end configuration
+                else
+                    state="MODE"
+                fi
+                ;;
+            *)
+                echo "Invalid state encountered in configure_shared: $state"
+                return 1
+                ;;
+        esac
+    done
+}
 
-if [ "$JAIA_MODE" = "simulation" ]; then
-    db_input medium jaiabot-embedded/warp || true
-    db_go
-fi
+# State machine for "bot" configuration
+configure_bot() {
+    local state="BOT_ID"
+    while true; do
+        case $state in
+            "BOT_ID")
+                if debconf_input_and_go high jaiabot-embedded/bot_id; then
+                    state="ARDUINO_TYPE"
+                fi
+                ;;
+            "ARDUINO_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/arduino_type; then
+                    db_get jaiabot-embedded/arduino_type
+                    ARDUINO_TYPE=$RET
+                    if [ "$ARDUINO_TYPE" = "usb_old" ] || [ "$ARDUINO_TYPE" = "usb_new" ]; then
+                        db_set jaiabot-embedded/arduino_type usb
+                    fi
+                    state="IMU_TYPE"
+                else
+                    state="BOT_ID"
+                fi
+                ;;
+            "IMU_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/imu_type; then
+                    state="BOT_TYPE"
+                else
+                    state="ARDUINO_TYPE"
+                fi
+                ;;
+            "BOT_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/bot_type; then
+                    state="DATA_OFFLOAD_IGNORE_TYPE"
+                else
+                    state="IMU_TYPE"
+                fi
+                ;;
+            "DATA_OFFLOAD_IGNORE_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/data_offload_ignore_type; then
+                    state="IMU_INSTALL_TYPE"
+                else
+                    state="BOT_TYPE"
+                fi
+                ;;
+            "IMU_INSTALL_TYPE")
+                if debconf_input_and_go high jaiabot-embedded/imu_install_type; then
+                    return 0  # Success, end configuration
+                else
+                    state="DATA_OFFLOAD_IGNORE_TYPE"
+                fi
+                ;;
+            *)
+                echo "Invalid state encountered in configure_bot: $state"
+                return 1
+                ;;
+        esac
+    done
+}
+
+# State machine for "hub" configuration
+configure_hub() {
+    local state="HUB_ID"
+    while true; do
+        case $state in
+            "HUB_ID")
+                if debconf_input_and_go high jaiabot-embedded/hub_id; then
+                    return 0  # Success, end configuration
+                fi
+                ;;
+            *)
+                echo "Invalid state encountered in configure_hub: $state"
+                return 1
+                ;;
+        esac
+    done
+}
+
+# Invoke the shared configuration state machine (both bot/hub settings)
+configure_shared
 
 db_get jaiabot-embedded/type
 JAIA_TYPE=$RET
+
 if [ "$JAIA_TYPE" = "bot" ]; then
-    db_input high jaiabot-embedded/bot_id || true
-    db_go
-
-    db_input high jaiabot-embedded/arduino_type || true
-    db_go
-
-    db_get jaiabot-embedded/arduino_type
-    ARDUINO_TYPE=$RET  
-    if [ "$ARDUINO_TYPE" = "usb_old" ] || [ "$ARDUINO_TYPE" = "usb_new" ]; then
-        db_set jaiabot-embedded/arduino_type usb
-    fi
-    
-    db_input high jaiabot-embedded/imu_type || true
-    db_go
-
-    db_input high jaiabot-embedded/bot_type || true
-    db_go
-
-    db_input high jaiabot-embedded/data_offload_ignore_type || true
-    db_go
-
-    db_input high jaiabot-embedded/imu_install_type || true
-    db_go
-
+    configure_bot
 elif [ "$JAIA_TYPE" = "hub" ]; then
-    db_input high jaiabot-embedded/hub_id || true
-    db_go
+    configure_hub
 fi
-
-db_input high jaiabot-embedded/fleet_id || true
-db_go
-
-db_input high jaiabot-embedded/led_type || true
-db_go
-
-db_input high jaiabot-embedded/electronics_stack || true
-db_go
-
-db_input medium jaiabot-embedded/user_role || true
-db_go

--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -1,14 +1,14 @@
-Template: jaiabot-embedded/common_debconf_state
+Template: jaiabot-embedded/debconf_state_common
 Type: select
 Choices: type, fleet_id, led_type, electronics_stack, mode, warp, NEXT
-Description: Choose an option to edit
+Description: Choose a common option to edit
 
-Template: jaiabot-embedded/bot_debconf_state
+Template: jaiabot-embedded/debconf_state_bot
 Type: select
 Choices: BACK, bot_id, arduino_type, imu_type, bot_type, data_offload_ignore_type, imu_install_type, EXIT
 Description: Choose a bot option to edit
 
-Template: jaiabot-embedded/hub_debconf_state
+Template: jaiabot-embedded/debconf_state_hub
 Type: select
 Choices: BACK, hub_id, user_role, EXIT
 Description: Choose a hub option to edit

--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -1,3 +1,18 @@
+Template: jaiabot-embedded/common_debconf_state
+Type: select
+Choices: type, fleet_id, led_type, electronics_stack, mode, warp, NEXT
+Description: Choose an option to edit
+
+Template: jaiabot-embedded/bot_debconf_state
+Type: select
+Choices: BACK, bot_id, arduino_type, imu_type, bot_type, data_offload_ignore_type, imu_install_type, EXIT
+Description: Choose a bot option to edit
+
+Template: jaiabot-embedded/hub_debconf_state
+Type: select
+Choices: BACK, hub_id, user_role, EXIT
+Description: Choose a hub option to edit
+
 Template: jaiabot-embedded/type
 Type: select
 Choices: bot, hub


### PR DESCRIPTION
Rewrote jaiabot-embedded.config script to allow user to "back up" and re-answer questions already answered (if the original answer was incorrect). Inspired by http://www.fifi.org/doc/debconf-doc/tutorial.html#AEN217

Create four state machines for asking questions during package configuration (debconf). This allows the user to hit "Cancel" (**or the Esc key**) and choose a different part of the config to edit:

- overarching config: Common then Bot or Hub (or BACK to Common from Bot/Hub specific)
- Common config: debconf questions relevant to bots and hubs
- Bot config: debconf questions only relevant to bots (called only if type == bot)
- Hub config: debconf questions only relevant to hubs (called only if type == hub)

This rearranging means that questions will be asked in a different order to before (all Common questions, followed by Bot or Hub specific questions).

Also to implement I had to add three new debconf variables (jaiabot-embedded/debconf_state_*) to create the menus.

`jaiabot-embedded/user_role` was moved from the Common block to Hub specific.

https://github.com/jaiarobotics/jaiabot-debian/assets/732276/383b0294-3cc1-44db-80fe-81aa7c53779a


