### PR TITLE
Use the /etc/jaiabot/software_version file

### DIFF
--- a/jaiabot-embedded.postinst
+++ b/jaiabot-embedded.postinst
@@ -166,6 +166,8 @@ else
   echo "jaiabot-status Alias already exists in /home/jaia/.bashrc"
 fi
 
+echo "jaiabot-embedded version: $(dpkg-query --show --showformat='${Version}' jaiabot-embedded)" > /etc/jaiabot/software_version
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
This pull request should be used in conjunction with the jaiabot PR of the same name.
The jaiabot-debian postinst script writes the package version to the /etc/jaiabot/software_version file, which is read by jaiabot-status script.
Using the deployment script writes the deployed version to this same file, so it acts as the single source of truth about what is actually installed and running on the bot.