### PR TITLE
Fix bug with missing arduino type on Hub

### DIFF
--- a/jaiabot-embedded.templates
+++ b/jaiabot-embedded.templates
@@ -64,6 +64,7 @@ Description: Fleet identification number
 
 Template: jaiabot-embedded/arduino_type
 Type: select
+Default: none
 Choices: spi, usb, none
 Description: What type of Arduino connection does this bot have?
 


### PR DESCRIPTION
Found bug when doing `apt purge jaiabot-embedded` and then `apt install jaiabot-embedded` for hub.