### PR TITLE
Missing dependency on python3-netifaces for jaiabot-config

### DIFF
--- a/control
+++ b/control
@@ -73,7 +73,7 @@ Description: Compiled Arduino sketches for the Jaiabot Project
  The jaiabot project provides binaries and libraries for the Jaiabot Autonomous Underwater Vehicle: https://www.jaia.tech/
 
 Package: jaiabot-config
-Depends: ${shlibs:Depends}, ${misc:Depends}
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3-netifaces
 Section: science
 Architecture: all
 Description: Runtime configuration generation for the Jaiabot Project applications


### PR DESCRIPTION
python3-netifaces is brought in by netplan.io but we should explicitly declare our dependency.

This was discovered by @Jroybot in Docker.